### PR TITLE
Annotate feature

### DIFF
--- a/commands/annotate.sh
+++ b/commands/annotate.sh
@@ -21,10 +21,4 @@ args=(
   "--workdir" "/annotate"
   "--env" "GITHUB_TOKEN"
 )
-# Pass to the Docker container all environment variables that begin with 'BUNDLE_'
-while IFS='=' read -r name _ ; do
-  if [[ $name =~ ^BUNDLE_ ]] ; then
-    args+=( "--env" "${name}" )
-  fi
-done < <(env | sort)
 docker run "${args[@]}" "${image}" /unwrappr/annotate.sh "${repository}" "${pull_request}"

--- a/tests/annotate.bats
+++ b/tests/annotate.bats
@@ -44,29 +44,6 @@ load '/usr/local/lib/bats/load.bash'
   unstub git
 }
 
-@test "Annotate passes BUNDLE_* environment variables to Docker container" {
-  export BUNDLE_RUBYGEMS__EXAMPLE__COM=secret1
-  export BUNDLE_RUBYGEMS__EXAMPLE__NET=secret2
-  export NOT_AS_BUNDLE_VAR=secret3
-
-  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_ANNOTATE=true
-  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_REPOSITORY=envato/ruby-service
-  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
-
-  stub docker \
-    "pull ruby : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby /unwrappr/annotate.sh envato/ruby-service 42 : echo pull request annotated"
-  stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "pulled image"
-  assert_output --partial "pull request annotated"
-  unstub docker
-  unstub git
-}
-
 @test "Annotate obtains the pull request number from build metadata" {
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_ANNOTATE=true
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_REPOSITORY=envato/ruby-service

--- a/unwrappr/annotate.sh
+++ b/unwrappr/annotate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "--- :bundler: Installing Unwrappr"
 cat <<\GEMS > Gemfile
 source 'https://rubygems.org/'
-gem 'unwrappr', source: 'https://rubygems.envato.net/'
+gem 'unwrappr'
 GEMS
 bundle install --jobs="$(nproc)"
 


### PR DESCRIPTION
The annotate feature adds comments to each gem change to a `Gemfile.lock` file in a Github pull request. These comments provide some context and are helpful to engineers when determining if the change in version is safe.

This functionality is provided by the [unwrappr](https://github.com/envato/unwrappr) library.