### PR TITLE
Adding the github.com host key prior to bundle update

### DIFF
--- a/update/update.sh
+++ b/update/update.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-set -euox pipefail
+set -euo pipefail
 
 # Bundle updating may download gems from git
 # we need to add github.com host key to known_hosts file
 # or the build will hang at the prompt to accept the key
+mkdir -p ~/.ssh && touch ~/.ssh/known_hosts
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
 cd /bundle_update

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bundle updating may download gems for git
+# need to add github.com host key to known_hosts
+# or the build will hang at accept prompt
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
 cd /bundle_update
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bundle updating may download gems for git
+# Bundle updating may download gems from git
 # need to add github.com host key to known_hosts
 # or the build will hang at accept prompt
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts

--- a/update/update.sh
+++ b/update/update.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Bundle updating may download gems from git
-# need to add github.com host key to known_hosts
-# or the build will hang at accept prompt
+# we need to add github.com host key to known_hosts file
+# or the build will hang at the prompt to accept the key
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
 cd /bundle_update

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euox pipefail
 
 # Bundle updating may download gems from git
 # we need to add github.com host key to known_hosts file


### PR DESCRIPTION
## Context
When attempting to run a `bundle update` for one of our apps, we have some gems that are downloaded directly from git.
It appears that when bundler is attempting to fetch them the interface will hang as the `github.com` host key has not been added to the docker images `known_hosts` file.
When this happens the build will just hang waiting for input.

This change attempts to fix that.

<img width="1187" alt="Screen Shot 2019-07-31 at 3 12 07 pm" src="https://user-images.githubusercontent.com/199240/62185422-cf46a500-b3a5-11e9-84f8-846d7c064167.png">

## Testing
I'm unsure of how to write a test for this, would welcome some feedback.