### PR TITLE
Provide ability to run a pre bundle update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ steps:
           pull-request-metadata-key: "github-pull-request-plugin-number"
 ```
 
+## Installing Custom Dependencies
+
+When running a bundle update from within a docker container, there may or may not
+be the dependencies you require for the update to complete successfully.
+For example, compiling native extensions or access to a library from another package.
+
+In this case you have 2 options to help solve the problem.
+
+1. Use a docker container which you have prebuilt (or sourced) with all the
+   required dependencies.
+
+2. In the project place a script in the `.buildkite/scripts/pre-bundle-update`.
+   This plugin will look for a script with this name in this location to execute
+   prior to the `bundle update`. Ensure it is executable `chmod +x`.
+
 ## Example Pipeline
 
 This is an example pipeline which ties everything together to produce nicely

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ In this case you have 2 options to help solve the problem.
 1. Use a docker container which you have prebuilt (or sourced) with all the
    required dependencies.
 
-2. You can specify a script location which will be executed prior to running the
+2. You can specify a script location or shell command which will be executed prior to running the
    bundle update. Here you can install and configure the container as needed.
 
 ```yml
@@ -158,6 +158,17 @@ steps:
       - envato/bundle-update#v0.7.0:
           update: true
           pre-bundle-update: .buildkite/scripts/pre-bundle-update
+```
+
+or a command
+
+```yml
+steps:
+  - label: ":bundler: Update"
+    plugins:
+      - envato/bundle-update#v0.7.0:
+          update: true
+          pre-bundle-update: "apk add --no-progress build-base"
 ```
 
 ## Example Pipeline
@@ -253,6 +264,12 @@ The Docker image to use. Checkout the [official Ruby
 builds](https://hub.docker.com/_/ruby/) at Docker Hub or build your own.
 
 Default: `ruby:slim`
+
+### `pre-bundle-update` (optional, update only)
+
+The script or command to run inside the docker container prior to the bundle update.
+Used to install any dependencies that the bundle update needs if not already in
+the container.
 
 ### `annotate`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This function runs `bundle update` from within a Docker container.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           update: true
 ```
 
@@ -27,7 +27,7 @@ we can make use of the [Git Commit Buildkite Plugin].
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           update: true
       - thedyrt/git-commit#v0.3.0:
           branch: "bundle-update/${BUILDKITE_BUILD_NUMBER}"
@@ -60,7 +60,7 @@ constraints also.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           update: true
           image: "ruby:2.3.7-slim"
 ```
@@ -76,7 +76,7 @@ steps:
       - ecr#v1.1.4:
           login: true
           account_ids: 100000000000
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           update: true
           image: "100000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:latest"
 ```
@@ -105,7 +105,7 @@ This feature is implemented using the [unwrappr] library.
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           annotate: true
           pull-request: 42
 ```
@@ -118,7 +118,7 @@ repository:
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           annotate: true
           pull-request: 42
           repository: "owner/project"
@@ -132,7 +132,7 @@ the [Github Pull Request Buildkite Plugin] saves the PR number with the key
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           annotate: true
           pull-request-metadata-key: "github-pull-request-plugin-number"
 ```
@@ -177,7 +177,7 @@ steps:
 
   - name: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           update: true
           image: "ruby:2.5"
       - thedyrt/git-commit#v0.3.0:
@@ -216,7 +216,7 @@ steps:
 
   - label: ":writing_hand: Annotate Changes"
     plugins:
-      - envato/bundle-update#v0.6.0:
+      - envato/bundle-update#v0.7.0:
           annotate: true
           pull-request-metadata-key: github-pull-request-plugin-number
 ```

--- a/README.md
+++ b/README.md
@@ -148,9 +148,17 @@ In this case you have 2 options to help solve the problem.
 1. Use a docker container which you have prebuilt (or sourced) with all the
    required dependencies.
 
-2. In the project place a script in the `.buildkite/scripts/pre-bundle-update`.
-   This plugin will look for a script with this name in this location to execute
-   prior to the `bundle update`. Ensure it is executable `chmod +x`.
+2. You can specify a script location which will be executed prior to running the
+   bundle update. Here you can install and configure the container as needed.
+
+```yml
+steps:
+  - label: ":bundler: Update"
+    plugins:
+      - envato/bundle-update#v0.7.0:
+          update: true
+          pre-bundle-update: .buildkite/scripts/pre-bundle-update
+```
 
 ## Example Pipeline
 

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -15,6 +15,7 @@ args=(
   "--volume" "$PLUGIN_DIR/update:/update"
   "--workdir" "/bundle_update"
   "--env" "BUNDLE_APP_CONFIG=/bundle_app_config"
+  "--env" "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
 )
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^BUNDLE_ ]] ; then

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby:slim}
 
+script=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE:-""}
+
 echo "--- :docker: Fetching the latest ${image} image"
 docker pull "${image}"
 
@@ -15,7 +17,7 @@ args=(
   "--volume" "$PLUGIN_DIR/update:/update"
   "--workdir" "/bundle_update"
   "--env" "BUNDLE_APP_CONFIG=/bundle_app_config"
-  "--env" "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
+  "--env" "PRE_BUNDLE_UPDATE=${script}"
 )
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^BUNDLE_ ]] ; then

--- a/hooks/command
+++ b/hooks/command
@@ -25,7 +25,10 @@ fi
 # Dispatch to the command file
 if in_array "UPDATE" "${commands[@]}" ; then
   # shellcheck source=commands/update.sh
-  . "$PLUGIN_DIR/commands/update.sh"
+  foo="$(plugin_read_config PRE_BUNDLE_UPDATE)"
+  echo $foo
+
+  PRE_BUNDLE_UPDATE="${foo}" . "$PLUGIN_DIR/commands/update.sh"
 elif in_array "ANNOTATE" "${commands[@]}" ; then
   # shellcheck source=commands/annotate.sh
   . "$PLUGIN_DIR/commands/annotate.sh"

--- a/hooks/command
+++ b/hooks/command
@@ -29,7 +29,7 @@ if in_array "UPDATE" "${commands[@]}" ; then
   echo "HIIIIII"
   echo $foo
 
-  PRE_BUNDLE_UPDATE="${foo}" eval "$PLUGIN_DIR/commands/update.sh"
+  PRE_BUNDLE_UPDATE="${foo}" . "$PLUGIN_DIR/commands/update.sh"
 elif in_array "ANNOTATE" "${commands[@]}" ; then
   # shellcheck source=commands/annotate.sh
   . "$PLUGIN_DIR/commands/annotate.sh"

--- a/hooks/command
+++ b/hooks/command
@@ -26,6 +26,7 @@ fi
 if in_array "UPDATE" "${commands[@]}" ; then
   # shellcheck source=commands/update.sh
   foo="$(plugin_read_config PRE_BUNDLE_UPDATE)"
+  echo "HIIIIII"
   echo $foo
 
   PRE_BUNDLE_UPDATE="${foo}" . "$PLUGIN_DIR/commands/update.sh"

--- a/hooks/command
+++ b/hooks/command
@@ -25,7 +25,6 @@ fi
 # Dispatch to the command file
 if in_array "UPDATE" "${commands[@]}" ; then
   # shellcheck source=commands/update.sh
-  foo="$(plugin_read_config PRE_BUNDLE_UPDATE)"
   . "$PLUGIN_DIR/commands/update.sh"
 elif in_array "ANNOTATE" "${commands[@]}" ; then
   # shellcheck source=commands/annotate.sh

--- a/hooks/command
+++ b/hooks/command
@@ -26,10 +26,7 @@ fi
 if in_array "UPDATE" "${commands[@]}" ; then
   # shellcheck source=commands/update.sh
   foo="$(plugin_read_config PRE_BUNDLE_UPDATE)"
-  echo "HIIIIII"
-  echo $foo
-
-  PRE_BUNDLE_UPDATE="${foo}" . "$PLUGIN_DIR/commands/update.sh"
+  . "$PLUGIN_DIR/commands/update.sh"
 elif in_array "ANNOTATE" "${commands[@]}" ; then
   # shellcheck source=commands/annotate.sh
   . "$PLUGIN_DIR/commands/annotate.sh"

--- a/hooks/command
+++ b/hooks/command
@@ -29,7 +29,7 @@ if in_array "UPDATE" "${commands[@]}" ; then
   echo "HIIIIII"
   echo $foo
 
-  PRE_BUNDLE_UPDATE="${foo}" . "$PLUGIN_DIR/commands/update.sh"
+  PRE_BUNDLE_UPDATE="${foo}" eval "$PLUGIN_DIR/commands/update.sh"
 elif in_array "ANNOTATE" "${commands[@]}" ; then
   # shellcheck source=commands/annotate.sh
   . "$PLUGIN_DIR/commands/annotate.sh"

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,6 +7,8 @@ configuration:
   properties:
     image:
       type: string
+    pre-bundle-update:
+      type: string
     pull-request:
       type: integer
       minimum: 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,8 +7,6 @@ configuration:
   properties:
     image:
       type: string
-    pre-bundle-update:
-      type: string
     pull-request:
       type: integer
       minimum: 1

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -9,10 +9,11 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Runs the bundle update via Docker" {
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_UPDATE=true
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE=""
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env PRE_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -31,7 +32,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env PRE_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -49,7 +50,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env PRE_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 0"
   stub buildkite-agent "annotate ':bundler: No gem updates found.' --style info : echo buildkite-annotation-added"
 
@@ -68,7 +69,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull my-image : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE my-image /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env PRE_BUNDLE_UPDATE= my-image /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -90,7 +91,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env PRE_BUNDLE_UPDATE= --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -12,7 +12,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -31,7 +31,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -49,7 +49,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 0"
   stub buildkite-agent "annotate ':bundler: No gem updates found.' --style info : echo buildkite-annotation-added"
 
@@ -68,7 +68,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull my-image : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config my-image /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE my-image /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -90,7 +90,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-
-function plugin_read_config() {
-  local var="BUILDKITE_PLUGIN_BUNDLE_UPDATE_${1}"
-  local default="${2:-}"
-  echo "${!var:-$default}"
-}
-
-
 cd /bundle_update
-pre_bundle_update=$(plugin_read_config PRE_BUNDLE_UPDATE)
-echo "pre_bundle_update=${pre_bundle_update}"
+
+echo "pre_bundle_update=${PRE_BUNDLE_UPDATE}"
 
 if [ -f "$pre_bundle_update" ]; then
     echo "$pre_bundle_update exist"

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd /bundle_update
-
 PLUGIN_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)/.."
 
 # shellcheck source=lib/config.sh
 . "$PLUGIN_DIR/lib/config.sh"
 
+cd /bundle_update
 pre_bundle_update=$(plugin_read_config PRE_BUNDLE_UPDATE)
+echo "pre_bundle_update=${pre_bundle_update}"
 
 if [ -f "$pre_bundle_update" ]; then
     echo "$pre_bundle_update exist"
@@ -20,5 +20,6 @@ fi
 eval pre_bundle_update
 # custom defined script
 # run it..
+
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 cd /bundle_update
 
-# echo "pre_bundle_update=$PRE_BUNDLE_UPDATE"
+echo "pre_bundle_update=${PRE_BUNDLE_UPDATE}"
 
-echo "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE=$BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
-
+echo "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE}"
+pre_bundle_update=${PRE_BUNDLE_UPDATE}
 if [ -f "$pre_bundle_update" ]; then
     echo "$pre_bundle_update exist"
 else

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "pre_bundle_update=$PRE_BUNDLE_UPDATE"
+# echo "pre_bundle_update=$PRE_BUNDLE_UPDATE"
 
 echo "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE=$BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 cd /bundle_update
 
-. "buildkite/scripts/pre-bundle-update"
+eval ".buildkite/scripts/pre-bundle-update"
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd /bundle_update
 
 if [ -f ".buildkite/scripts/pre-bundle-update" ]; then
-    echo "Installing custom dependencies..."
+    echo ":package: Installing custom dependencies..."
     eval ".buildkite/scripts/pre-bundle-update"
 fi
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 cd /bundle_update
 
-if [ -f ".buildkite/scripts/pre-bundle-update" ]; then
-    echo "Installing custom dependencies..."
-    eval ".buildkite/scripts/pre-bundle-update"
+if [ -f $BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ]; then
+    echo "Running pre install script..."
+    eval $BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE
 fi
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -20,7 +20,7 @@ else
     pre_bundle_update="./buildkite/scripts/pre-bundle-update"
 fi
 
-eval "./buildkite/scripts/pre-bundle-update"
+eval ".buildkite/scripts/pre-bundle-update"
 # custom defined script
 # run it..
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "pre_bundle_update=${PRE_BUNDLE_UPDATE}"
+echo "pre_bundle_update=$PRE_BUNDLE_UPDATE"
+
+echo "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE=$BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
 
 if [ -f "$pre_bundle_update" ]; then
     echo "$pre_bundle_update exist"

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 cd /bundle_update
 
-if [ -f $PRE_BUNDLE_UPDATE ]; then
+if [ -f "$PRE_BUNDLE_UPDATE" ]; then
   echo "Running pre install script..."
-  eval $PRE_BUNDLE_UPDATE
+  eval "$PRE_BUNDLE_UPDATE"
 fi
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLUGIN_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)/.."
+local var="BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
 
-# shellcheck source=lib/config.sh
-. "$PLUGIN_DIR/lib/config.sh"
+echo "var=${var}"
+
 
 cd /bundle_update
 pre_bundle_update=$(plugin_read_config PRE_BUNDLE_UPDATE)

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 cd /bundle_update
 
-if [ -f $BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE ]; then
-    echo "Running pre install script..."
-    eval $BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE
+if [ -f $PRE_BUNDLE_UPDATE ]; then
+  echo "Running pre install script..."
+  eval $PRE_BUNDLE_UPDATE
 fi
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 
-echo "file_name=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE}"
+function plugin_read_config() {
+  local var="BUILDKITE_PLUGIN_BUNDLE_UPDATE_${1}"
+  local default="${2:-}"
+  echo "${!var:-$default}"
+}
 
 
 cd /bundle_update
@@ -16,7 +20,7 @@ else
     pre_bundle_update="./buildkite/scripts/pre-bundle-update"
 fi
 
-eval pre_bundle_update
+eval "./buildkite/scripts/pre-bundle-update"
 # custom defined script
 # run it..
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,12 +3,7 @@ set -euo pipefail
 
 cd /bundle_update
 
-if [ -f "$PRE_BUNDLE_UPDATE" ]; then
-  echo "Running pre install script..."
-  eval "$PRE_BUNDLE_UPDATE"
-else
-  echo "Specified file location does not exist $PRE_BUNDLE_UPDATE"
-  exit 1
-fi
+echo "Running pre install script..."
+eval "$PRE_BUNDLE_UPDATE"
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd /bundle_update
 
-eval ".buildkite/scripts/pre-bundle-update"
+if [ -f ".buildkite/scripts/pre-bundle-update" ]; then
+    echo "Installing custom dependencies..."
+    eval ".buildkite/scripts/pre-bundle-update"
+fi
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -8,6 +8,7 @@ if [ -f "$PRE_BUNDLE_UPDATE" ]; then
   eval "$PRE_BUNDLE_UPDATE"
 else
   echo "Specified file location does not exist $PRE_BUNDLE_UPDATE"
+  exit 1
 fi
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 cd /bundle_update
 
+PLUGIN_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)/.."
+
+# shellcheck source=lib/config.sh
+. "$PLUGIN_DIR/lib/config.sh"
+
 pre_bundle_update=$(plugin_read_config PRE_BUNDLE_UPDATE)
 
 if [ -f "$pre_bundle_update" ]; then

--- a/update/update.sh
+++ b/update/update.sh
@@ -6,6 +6,8 @@ cd /bundle_update
 if [ -f "$PRE_BUNDLE_UPDATE" ]; then
   echo "Running pre install script..."
   eval "$PRE_BUNDLE_UPDATE"
+else
+  echo "Specified file location does not exist $PRE_BUNDLE_UPDATE"
 fi
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -2,4 +2,10 @@
 set -euo pipefail
 
 cd /bundle_update
+
+# check if hook file exists.
+.buildkite/scripts/pre-bundle-update
+# custom defined script
+# run it..
+
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,8 +3,16 @@ set -euo pipefail
 
 cd /bundle_update
 
-# check if hook file exists.
-.buildkite/scripts/pre-bundle-update
+pre_bundle_update=$(plugin_read_config PRE_BUNDLE_UPDATE)
+
+if [ -f "$pre_bundle_update" ]; then
+    echo "$pre_bundle_update exist"
+else
+    echo "$pre_bundle_update does not exist"
+    pre_bundle_update="./buildkite/scripts/pre-bundle-update"
+fi
+
+eval pre_bundle_update
 # custom defined script
 # run it..
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,20 +3,6 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "pre_bundle_update=${PRE_BUNDLE_UPDATE}"
-
-echo "BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE}"
-pre_bundle_update=${PRE_BUNDLE_UPDATE}
-if [ -f "$pre_bundle_update" ]; then
-    echo "$pre_bundle_update exist"
-else
-    echo "$pre_bundle_update does not exist"
-    pre_bundle_update="./buildkite/scripts/pre-bundle-update"
-fi
-
-eval ".buildkite/scripts/pre-bundle-update"
-# custom defined script
-# run it..
-
+. "buildkite/scripts/pre-bundle-update"
 
 bundle update --jobs="$(nproc)"

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-local var="BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE"
 
-echo "var=${var}"
+echo "file_name=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE}"
 
 
 cd /bundle_update

--- a/update/update.sh
+++ b/update/update.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd /bundle_update
 
 if [ -f ".buildkite/scripts/pre-bundle-update" ]; then
-    echo ":package: Installing custom dependencies..."
+    echo "Installing custom dependencies..."
     eval ".buildkite/scripts/pre-bundle-update"
 fi
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "Running pre install script..."
+echo "Running pre install script or command..."
 eval "$PRE_BUNDLE_UPDATE"
 
 bundle update --jobs="$(nproc)"


### PR DESCRIPTION
## Context
I was attempting to use this plugin, and came across an issue where I needed to install a app which was needed for the `bundle update` to pass.
The application that I'm configuring does not have it's 'own' docker container nor do I want to create and manage one seeing as thought the bundle update process will only be executed once a week or so. This means to me that build times are irrelevant and I don't mind the build taking a long time building a container.

This PR is the result of my 2nd approach, which seems _a lot_ simpler than my first approach.
This PR just uses a simple convention of 'put the script here and if it exists, it will run' similar to the `hooks`. I chose `.buildkite/scripts/pre-bundle-update` for this. `hooks` appears to be used more for the buildkite functionality so a scripts directory seemed more appropriate.

I've tested this very simply and it appears to work ok.

FYI the second approach was with a defined parameter in the pipeline.yml to point to the script directory. My noobness with writing buildkite plugins seem to get the better of me and I found it difficult to get it working correctly. (as you can see with the commit history)
So I defaulted back to the convention approach with also seems a lot simpler in implementation.

UPDATE

gone back to the script being passed in explicitly. Seems just as easy to just pass it into the docker command.