### PR TITLE
Support post-bundle-update Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This function runs `bundle update` from within a Docker container.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
 ```
 
@@ -27,7 +27,7 @@ we can make use of the [Git Commit Buildkite Plugin].
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
       - thedyrt/git-commit#v0.3.0:
           branch: "bundle-update/${BUILDKITE_BUILD_NUMBER}"
@@ -60,7 +60,7 @@ constraints also.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
           image: "ruby:2.3.7-slim"
 ```
@@ -76,7 +76,7 @@ steps:
       - ecr#v1.1.4:
           login: true
           account_ids: 100000000000
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
           image: "100000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:latest"
 ```
@@ -105,7 +105,7 @@ This feature is implemented using the [unwrappr] library.
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           annotate: true
           pull-request: 42
 ```
@@ -118,7 +118,7 @@ repository:
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           annotate: true
           pull-request: 42
           repository: "owner/project"
@@ -132,7 +132,7 @@ the [Github Pull Request Buildkite Plugin] saves the PR number with the key
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           annotate: true
           pull-request-metadata-key: "github-pull-request-plugin-number"
 ```
@@ -155,7 +155,7 @@ In this case you have 2 options to help solve the problem.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
           pre-bundle-update: .buildkite/scripts/pre-bundle-update
 ```
@@ -166,7 +166,7 @@ or a command
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
           pre-bundle-update: "apk add --no-progress build-base"
 ```
@@ -196,7 +196,7 @@ steps:
 
   - name: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           update: true
           image: "ruby:2.5"
       - thedyrt/git-commit#v0.3.0:
@@ -235,7 +235,7 @@ steps:
 
   - label: ":writing_hand: Annotate Changes"
     plugins:
-      - envato/bundle-update#v0.7.0:
+      - envato/bundle-update#v0.8.0:
           annotate: true
           pull-request-metadata-key: github-pull-request-plugin-number
 ```

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ builds](https://hub.docker.com/_/ruby/) at Docker Hub or build your own.
 
 Default: `ruby:slim`
 
+### `post-bundle-update` (optional, update only)
+
+A script or command to run inside the docker container after the bundle update.
+
 ### `pre-bundle-update` (optional, update only)
 
 The script or command to run inside the docker container prior to the bundle update.

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -5,10 +5,10 @@ image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby:slim}
 pre_bundle_update=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE:-""}
 post_bundle_update=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_POST_BUNDLE_UPDATE:-""}
 
-echo "--- :docker: Fetching the latest ${image} image"
+echo "~~~ :docker: Fetching the latest ${image} image"
 docker pull "${image}"
 
-echo "+++ :bundler: Running bundle update"
+echo "~~~ :docker: Starting up ${image} container"
 args=(
   "--interactive"
   "--tty"

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby:slim}
-
-script=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE:-""}
+pre_bundle_update=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_PRE_BUNDLE_UPDATE:-""}
+post_bundle_update=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_POST_BUNDLE_UPDATE:-""}
 
 echo "--- :docker: Fetching the latest ${image} image"
 docker pull "${image}"
@@ -17,7 +17,8 @@ args=(
   "--volume" "$PLUGIN_DIR/update:/update"
   "--workdir" "/bundle_update"
   "--env" "BUNDLE_APP_CONFIG=/bundle_app_config"
-  "--env" "PRE_BUNDLE_UPDATE=${script}"
+  "--env" "PRE_BUNDLE_UPDATE=${pre_bundle_update}"
+  "--env" "POST_BUNDLE_UPDATE=${post_bundle_update}"
 )
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^BUNDLE_ ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,6 +7,8 @@ configuration:
   properties:
     image:
       type: string
+    post-bundle-update:
+      type: string
     pre-bundle-update:
       type: string
     pull-request:
@@ -25,5 +27,7 @@ configuration:
       - update
   dependencies:
     image: [ update ]
+    post-bundle-update: [ update ]
+    pre-bundle-update: [ update ]
     pull-request: [ annotate ]
     repository: [ annotate ]

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 cd /bundle_update
 

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "Running pre bundle update"
+echo "--- :shell: Running pre bundle update"
 eval "$PRE_BUNDLE_UPDATE"
 
+echo "+++ :bundler: Running bundle update"
 bundle update --jobs="$(nproc)"
 
-echo "Running post bundle update"
+echo "--- :shell: Running post bundle update"
 eval "$POST_BUNDLE_UPDATE"

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "--- :shell: Running pre bundle update"
-eval "$PRE_BUNDLE_UPDATE"
+if [ -n "$PRE_BUNDLE_UPDATE" ]; then
+  echo "--- :shell: Running pre bundle update"
+  eval "$PRE_BUNDLE_UPDATE"
+fi
 
 echo "+++ :bundler: Running bundle update"
 bundle update --jobs="$(nproc)"
 
-echo "--- :shell: Running post bundle update"
-eval "$POST_BUNDLE_UPDATE"
+if [ -n "$POST_BUNDLE_UPDATE" ]; then
+  echo "--- :shell: Running post bundle update"
+  eval "$POST_BUNDLE_UPDATE"
+fi

--- a/update/update.sh
+++ b/update/update.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 cd /bundle_update
 
-echo "Running pre install script or command..."
+echo "Running pre bundle update"
 eval "$PRE_BUNDLE_UPDATE"
 
 bundle update --jobs="$(nproc)"
+
+echo "Running post bundle update"
+eval "$POST_BUNDLE_UPDATE"


### PR DESCRIPTION
Similar to the `pre-bundle-update` command, let's support a `post-bundle-update` command that runs after the `bundle update`. This allows for builds to perform some custom behaviour before changes are committed to source-control management.

```yaml
plugins:
  - envato/bundle-update#v0.8.0:
      update: true
      post-bundle-update: my-custom-behaviour.sh
```

See it in action here: https://buildkite.com/envato-marketplaces/marketplace-bundle-update/builds/12#66132b75-4a71-47b2-97c8-4952474e5d32