### PR TITLE
Use writable bundle config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This function runs `bundle update` from within a Docker container.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
 ```
 
@@ -27,7 +27,7 @@ we can make use of the [Git Commit Buildkite Plugin].
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
       - thedyrt/git-commit#v0.3.0:
           branch: "bundle-update/${BUILDKITE_BUILD_NUMBER}"
@@ -60,7 +60,7 @@ constraints also.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
           image: "ruby:2.3.7-slim"
 ```
@@ -76,7 +76,7 @@ steps:
       - ecr#v1.1.4:
           login: true
           account_ids: 100000000000
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
           image: "100000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:latest"
 ```
@@ -105,7 +105,7 @@ This feature is implemented using the [unwrappr] library.
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           annotate: true
           pull-request: 42
 ```
@@ -118,7 +118,7 @@ repository:
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           annotate: true
           pull-request: 42
           repository: "owner/project"
@@ -132,7 +132,7 @@ the [Github Pull Request Buildkite Plugin] saves the PR number with the key
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           annotate: true
           pull-request-metadata-key: "github-pull-request-plugin-number"
 ```
@@ -155,7 +155,7 @@ In this case you have 2 options to help solve the problem.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
           pre-bundle-update: .buildkite/scripts/pre-bundle-update
 ```
@@ -166,7 +166,7 @@ or a command
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
           pre-bundle-update: "apk add --no-progress build-base"
 ```
@@ -196,7 +196,7 @@ steps:
 
   - name: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           update: true
           image: "ruby:2.5"
       - thedyrt/git-commit#v0.3.0:
@@ -235,7 +235,7 @@ steps:
 
   - label: ":writing_hand: Annotate Changes"
     plugins:
-      - envato/bundle-update#v0.8.0:
+      - envato/bundle-update#v0.8.1:
           annotate: true
           pull-request-metadata-key: github-pull-request-plugin-number
 ```

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -16,7 +16,7 @@ args=(
   "--volume" "$PWD:/bundle_update"
   "--volume" "$PLUGIN_DIR/update:/update"
   "--workdir" "/bundle_update"
-  "--env" "BUNDLE_APP_CONFIG=/bundle_app_config"
+  "--env" "BUNDLE_APP_CONFIG=/tmp/bundle_app_config"
   "--env" "PRE_BUNDLE_UPDATE=${pre_bundle_update}"
   "--env" "POST_BUNDLE_UPDATE=${post_bundle_update}"
 )

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -12,7 +12,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -31,7 +31,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -49,7 +49,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 0"
   stub buildkite-agent "annotate ':bundler: No gem updates found.' --style info : echo buildkite-annotation-added"
 
@@ -68,7 +68,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull my-image : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= my-image /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= my-image /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -88,7 +88,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env PRE_BUNDLE_UPDATE=my-pre-bundle-update --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config --env PRE_BUNDLE_UPDATE=my-pre-bundle-update --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -108,7 +108,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE=my-post-bundle-update ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE=my-post-bundle-update ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 
@@ -130,7 +130,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby:slim /update/update.sh : echo bundle updated"
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= --env BUNDLE_RUBYGEMS__EXAMPLE__COM --env BUNDLE_RUBYGEMS__EXAMPLE__NET ruby:slim /update/update.sh : echo bundle updated"
   stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
   stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
 


### PR DESCRIPTION
Currently, we use `/bundle_app_config` as the Bundle config location. This works for fine for `root` user, but non-root users won't be able to create the directory as the user doesn't have enough permission to perform the operation.

This commit updates the Bundle config directory from `/bundle_app_config` to `/tmp/bundle_app_config` which going to fix the permission issue.