### PR TITLE
Use configured Ruby image on the annotation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ steps:
 
 Instruct the plugin to run `bundle update` on the project.
 
-### `image` (optional, update only)
+### `image` (optional)
 
 The Docker image to use. Checkout the [official Ruby
 builds](https://hub.docker.com/_/ruby/) at Docker Hub or build your own.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This function runs `bundle update` from within a Docker container.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
 ```
 
@@ -27,7 +27,7 @@ we can make use of the [Git Commit Buildkite Plugin].
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
       - thedyrt/git-commit#v0.3.0:
           branch: "bundle-update/${BUILDKITE_BUILD_NUMBER}"
@@ -60,7 +60,7 @@ constraints also.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
           image: "ruby:2.3.7-slim"
 ```
@@ -76,7 +76,7 @@ steps:
       - ecr#v1.1.4:
           login: true
           account_ids: 100000000000
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
           image: "100000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:latest"
 ```
@@ -105,7 +105,7 @@ This feature is implemented using the [unwrappr] library.
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           annotate: true
           pull-request: 42
 ```
@@ -118,7 +118,7 @@ repository:
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           annotate: true
           pull-request: 42
           repository: "owner/project"
@@ -132,7 +132,7 @@ the [Github Pull Request Buildkite Plugin] saves the PR number with the key
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           annotate: true
           pull-request-metadata-key: "github-pull-request-plugin-number"
 ```
@@ -155,7 +155,7 @@ In this case you have 2 options to help solve the problem.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
           pre-bundle-update: .buildkite/scripts/pre-bundle-update
 ```
@@ -166,7 +166,7 @@ or a command
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
           pre-bundle-update: "apk add --no-progress build-base"
 ```
@@ -196,7 +196,7 @@ steps:
 
   - name: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           update: true
           image: "ruby:2.5"
       - thedyrt/git-commit#v0.3.0:
@@ -235,7 +235,7 @@ steps:
 
   - label: ":writing_hand: Annotate Changes"
     plugins:
-      - envato/bundle-update#v0.8.1:
+      - envato/bundle-update#v0.9.0:
           annotate: true
           pull-request-metadata-key: github-pull-request-plugin-number
 ```

--- a/commands/annotate.sh
+++ b/commands/annotate.sh
@@ -7,7 +7,7 @@ if [[ -z "${pull_request}" ]]; then
   pull_request_metadata_key=$(plugin_read_config PULL_REQUEST_METADATA_KEY)
   pull_request=$(buildkite-agent meta-data get "${pull_request_metadata_key}")
 fi
-image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby}
+image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby:slim}
 
 echo "--- :docker: Fetching the latest ${image} image"
 docker pull "${image}"

--- a/commands/annotate.sh
+++ b/commands/annotate.sh
@@ -7,7 +7,7 @@ if [[ -z "${pull_request}" ]]; then
   pull_request_metadata_key=$(plugin_read_config PULL_REQUEST_METADATA_KEY)
   pull_request=$(buildkite-agent meta-data get "${pull_request_metadata_key}")
 fi
-image=ruby
+image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby}
 
 echo "--- :docker: Fetching the latest ${image} image"
 docker pull "${image}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,7 +26,6 @@ configuration:
     - required:
       - update
   dependencies:
-    image: [ update ]
     post-bundle-update: [ update ]
     pre-bundle-update: [ update ]
     pull-request: [ annotate ]

--- a/tests/annotate.bats
+++ b/tests/annotate.bats
@@ -13,8 +13,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
 
   stub docker \
-    "pull ruby : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh envato/ruby-service 42 : echo pull request annotated"
+    "pull ruby:slim : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby:slim /unwrappr/annotate.sh envato/ruby-service 42 : echo pull request annotated"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
 
   run $PWD/hooks/command
@@ -31,8 +31,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
 
   stub docker \
-    "pull ruby : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh owner/project 42 : echo pull request annotated"
+    "pull ruby:slim : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby:slim /unwrappr/annotate.sh owner/project 42 : echo pull request annotated"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
 
   run $PWD/hooks/command
@@ -50,8 +50,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST_METADATA_KEY=pull-request
 
   stub docker \
-    "pull ruby : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh envato/ruby-service 232 : echo pull request annotated"
+    "pull ruby:slim : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby:slim /unwrappr/annotate.sh envato/ruby-service 232 : echo pull request annotated"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent "meta-data get pull-request : echo 232"
 

--- a/tests/annotate.bats
+++ b/tests/annotate.bats
@@ -64,3 +64,23 @@ load '/usr/local/lib/bats/load.bash'
   unstub git
   unstub buildkite-agent
 }
+
+@test "Supports the image option" {
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_ANNOTATE=true
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_REPOSITORY=envato/ruby-service
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE=my-image
+
+  stub docker \
+    "pull my-image : echo pulled my-image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN my-image /unwrappr/annotate.sh envato/ruby-service 42 : echo pull request annotated"
+  stub git 'remote get-url origin : echo "git@github.com:owner/project"'
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled my-image"
+  assert_output --partial "pull request annotated"
+  unstub docker
+  unstub git
+}


### PR DESCRIPTION
### Context

Apparently `unwrappr` depends on Ruby `~> 2.3` and now that Ruby 3 has been released builds are failing.

### Changes

- add support to the image option on the annotation step, the same way it's used on the update step
- uses `ruby:slim` instead of `ruby` when annotating