### PR TITLE
Use ruby image for annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This function runs `bundle update` from within a Docker container.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
 ```
 
@@ -27,7 +27,7 @@ we can make use of the [Git Commit Buildkite Plugin].
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
       - thedyrt/git-commit#v0.3.0:
           branch: "bundle-update/${BUILDKITE_BUILD_NUMBER}"
@@ -60,7 +60,7 @@ constraints also.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
           image: "ruby:2.3.7-slim"
 ```
@@ -76,7 +76,7 @@ steps:
       - ecr#v1.1.4:
           login: true
           account_ids: 100000000000
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
           image: "100000000000.dkr.ecr.us-east-1.amazonaws.com/my-service:latest"
 ```
@@ -105,7 +105,7 @@ This feature is implemented using the [unwrappr] library.
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           annotate: true
           pull-request: 42
 ```
@@ -118,7 +118,7 @@ repository:
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           annotate: true
           pull-request: 42
           repository: "owner/project"
@@ -132,7 +132,7 @@ the [Github Pull Request Buildkite Plugin] saves the PR number with the key
 steps:
   - label: ":rubygems: Annotate Gem Changes"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           annotate: true
           pull-request-metadata-key: "github-pull-request-plugin-number"
 ```
@@ -155,7 +155,7 @@ In this case you have 2 options to help solve the problem.
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
           pre-bundle-update: .buildkite/scripts/pre-bundle-update
 ```
@@ -166,7 +166,7 @@ or a command
 steps:
   - label: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
           pre-bundle-update: "apk add --no-progress build-base"
 ```
@@ -196,7 +196,7 @@ steps:
 
   - name: ":bundler: Update"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           update: true
           image: "ruby:2.5"
       - thedyrt/git-commit#v0.3.0:
@@ -235,7 +235,7 @@ steps:
 
   - label: ":writing_hand: Annotate Changes"
     plugins:
-      - envato/bundle-update#v0.9.0:
+      - envato/bundle-update#v0.9.1:
           annotate: true
           pull-request-metadata-key: github-pull-request-plugin-number
 ```

--- a/commands/annotate.sh
+++ b/commands/annotate.sh
@@ -7,7 +7,7 @@ if [[ -z "${pull_request}" ]]; then
   pull_request_metadata_key=$(plugin_read_config PULL_REQUEST_METADATA_KEY)
   pull_request=$(buildkite-agent meta-data get "${pull_request_metadata_key}")
 fi
-image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby:slim}
+image=${BUILDKITE_PLUGIN_BUNDLE_UPDATE_IMAGE:-ruby}
 
 echo "--- :docker: Fetching the latest ${image} image"
 docker pull "${image}"

--- a/tests/annotate.bats
+++ b/tests/annotate.bats
@@ -13,8 +13,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
 
   stub docker \
-    "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby:slim /unwrappr/annotate.sh envato/ruby-service 42 : echo pull request annotated"
+    "pull ruby : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh envato/ruby-service 42 : echo pull request annotated"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
 
   run $PWD/hooks/command
@@ -31,8 +31,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
 
   stub docker \
-    "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby:slim /unwrappr/annotate.sh owner/project 42 : echo pull request annotated"
+    "pull ruby : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh owner/project 42 : echo pull request annotated"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
 
   run $PWD/hooks/command
@@ -50,8 +50,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST_METADATA_KEY=pull-request
 
   stub docker \
-    "pull ruby:slim : echo pulled image" \
-    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby:slim /unwrappr/annotate.sh envato/ruby-service 232 : echo pull request annotated"
+    "pull ruby : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh envato/ruby-service 232 : echo pull request annotated"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent "meta-data get pull-request : echo 232"
 


### PR DESCRIPTION
Unfortunately, `unwrappr` doesn't work when run on the `ruby:slim` Docker container. It requires git which isn't included in this image.

We'll need to revert to using the larger, `ruby` image.

```
bundler: failed to load command: unwrappr (/usr/local/bundle/bin/unwrappr)
/usr/local/bundle/gems/git-1.8.1/lib/git/lib.rb:1097:in `command': git '-c' 'color.ui=false' version   2>&1:sh: 1: git: not found (Git::GitExecuteError)
from /usr/local/bundle/gems/git-1.8.1/lib/git/lib.rb:990:in `current_command_version'
from /usr/local/bundle/gems/git-1.8.1/lib/git/lib.rb:1000:in `meets_required_version?'
from /usr/local/bundle/gems/git-1.8.1/lib/git.rb:28:in `<top (required)>'
from /usr/local/bundle/gems/unwrappr-0.5.0/lib/unwrappr/git_command_runner.rb:3:in `require'
from /usr/local/bundle/gems/unwrappr-0.5.0/lib/unwrappr/git_command_runner.rb:3:in `<top (required)>'
from /usr/local/bundle/gems/unwrappr-0.5.0/lib/unwrappr.rb:7:in `require'
from /usr/local/bundle/gems/unwrappr-0.5.0/lib/unwrappr.rb:7:in `<top (required)>'
from /usr/local/bundle/gems/unwrappr-0.5.0/exe/unwrappr:6:in `require'
from /usr/local/bundle/gems/unwrappr-0.5.0/exe/unwrappr:6:in `<top (required)>'
from /usr/local/bundle/bin/unwrappr:23:in `load'
from /usr/local/bundle/bin/unwrappr:23:in `<top (required)>'
from /usr/local/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
from /usr/local/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
from /usr/local/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
from /usr/local/lib/ruby/3.0.0/bundler/cli.rb:497:in `exec'
from /usr/local/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
from /usr/local/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
from /usr/local/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
from /usr/local/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
from /usr/local/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
from /usr/local/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
from /usr/local/lib/ruby/gems/3.0.0/gems/bundler-2.2.3/libexec/bundle:49:in `block in <top (required)>'
from /usr/local/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
from /usr/local/lib/ruby/gems/3.0.0/gems/bundler-2.2.3/libexec/bundle:37:in `<top (required)>'
from /usr/local/bin/bundle:23:in `load'
from /usr/local/bin/bundle:23:in `<main>'
🚨 Error: The command exited with status 1

```