### PR TITLE
Rename default git branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bundle Update Buildkite Plugin
 
-![Build status](https://badge.buildkite.com/3e169bf223b02ed62d3a3090e2ef78cb025e83076c33b694b5.svg?branch=master)
+![Build status](https://badge.buildkite.com/3e169bf223b02ed62d3a3090e2ef78cb025e83076c33b694b5.svg?branch=main)
 [![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE)
 
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that updates


### PR DESCRIPTION
#### Context

To be more welcoming and inclusive, the default git branch has been renamed to `main`.

#### Change

Update the build status badge to consider builds on the `main` branch.