### PR TITLE
Dual boot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ steps:
 
 Note how the values in the list can either be just a key (so the value is sourced from the environment) or a KEY=VALUE pair.
 
+### `gemfile-lock-files` (optional, update only)
+
+The Gemfile lock files to check for changes post `bundle update`.
+
+Default: `Gemfile.lock`
+
 ### `post-bundle-update` (optional, update only)
 
 A script or command to run inside the docker container after the bundle update.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ secrets bucket.
 ```yml
 steps:
 
-  - name: ":bundler: Update"
+  - label: ":bundler: Update"
     plugins:
       - envato/bundle-update#v0.9.1:
           update: true

--- a/README.md
+++ b/README.md
@@ -265,6 +265,23 @@ builds](https://hub.docker.com/_/ruby/) at Docker Hub or build your own.
 
 Default: `ruby:slim`
 
+### `env` (optional, update only)
+
+The environment variables that get passed to the docker container.
+
+```yml
+steps:
+  - name: ":bundler: Update"
+    plugins:
+      - envato/bundle-update#v0.9.1:
+          update: true
+          env:
+            - BUILDKITE_BUILD_NUMBER
+            - MY_CUSTOM_ENV=llamas
+```
+
+Note how the values in the list can either be just a key (so the value is sourced from the environment) or a KEY=VALUE pair.
+
 ### `post-bundle-update` (optional, update only)
 
 A script or command to run inside the docker container after the bundle update.

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -25,6 +25,12 @@ while IFS='=' read -r name _ ; do
     args+=( "--env" "${name}" )
   fi
 done < <(env | sort)
+
+# append env vars provided in ENV, these are newline delimited
+while IFS=$'\n' read -r env ; do
+  [[ -n "${env:-}" ]] && args+=("--env" "${env}")
+done <<< "$(printf '%s\n' "$(plugin_read_list ENV)")"
+
 docker run "${args[@]}" "${image}" /update/update.sh
 
 if git diff-index --quiet HEAD -- Gemfile.lock; then

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -33,8 +33,13 @@ done <<< "$(printf '%s\n' "$(plugin_read_list ENV)")"
 
 docker run "${args[@]}" "${image}" /update/update.sh
 
-if git diff-index --quiet HEAD -- Gemfile.lock; then
-  echo "No updates"
+# check the list of Gemfiles for changes, these are newline delimited
+gemfile_lock_files=()
+while IFS=$'\n' read -r gemfile_lock_file ; do
+  [[ -n "${gemfile_lock_file:-}" ]] && gemfile_lock_files+=("${gemfile_lock_file}")
+done <<< "$(printf '%s\n' "$(plugin_read_list GEMFILE_LOCK_FILES)")"
+
+if git diff-index --quiet HEAD -- "${gemfile_lock_files[@]-Gemfile.lock}"; then
   buildkite-agent annotate ":bundler: No gem updates found." --style info
 else
   buildkite-agent meta-data set bundle-update-plugin-changes true

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -6,3 +6,26 @@ function plugin_read_config() {
   local default="${2:-}"
   echo "${!var:-$default}"
 }
+
+# Reads either a value or a list from plugin config
+function plugin_read_list() {
+  prefix_read_list "BUILDKITE_PLUGIN_BUNDLE_UPDATE_$1"
+}
+
+# Reads either a value or a list from the given env prefix
+function prefix_read_list() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      echo "${!parameter}"
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    echo "${!prefix}"
+  fi
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,12 @@ requirements:
   - docker
 configuration:
   properties:
+    env:
+      type: [ string, array ]
+      minimum: 1
+    gemfile-lock-files:
+      type: [ string, array ]
+      minimum: 1
     image:
       type: string
     post-bundle-update:

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -143,3 +143,24 @@ load '/usr/local/lib/bats/load.bash'
   unstub git
   unstub buildkite-agent
 }
+
+@test "Passes environment variables" {
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_UPDATE=true
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_ENV_0="ZERO=0"
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_ENV_1="ONE=1"
+
+  stub docker \
+    "pull ruby:slim : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= --env ZERO=0 --env ONE=1 ruby:slim /update/update.sh : echo bundle updated"
+  stub git "diff-index --quiet HEAD -- Gemfile.lock : exit 1"
+  stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled image"
+  assert_output --partial "bundle updated"
+  unstub docker
+  unstub git
+  unstub buildkite-agent
+}

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -44,6 +44,25 @@ load '/usr/local/lib/bats/load.bash'
   unstub buildkite-agent
 }
 
+@test "Supports the gemfile-lock-files option" {
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_UPDATE=true
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_GEMFILE_LOCK_FILES=Gemfile_v2.lock
+
+  stub docker \
+    "pull ruby:slim : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin:/bundle_update --volume /plugin/hooks/../update:/update --workdir /bundle_update --env BUNDLE_APP_CONFIG=/tmp/bundle_app_config  --env PRE_BUNDLE_UPDATE= --env POST_BUNDLE_UPDATE= ruby:slim /update/update.sh : echo bundle updated"
+  stub git "diff-index --quiet HEAD -- Gemfile_v2.lock : exit 1"
+  stub buildkite-agent "meta-data set bundle-update-plugin-changes true : echo meta-data set"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "meta-data set"
+  unstub docker
+  unstub git
+  unstub buildkite-agent
+}
+
 @test "Adds buildkite annotation, but no metadata, when no changes are found" {
   export BUILDKITE_PLUGIN_BUNDLE_UPDATE_UPDATE=true
 


### PR DESCRIPTION
This PR adds the missing properties required to support updating multiple Gemfiles and passing environment variables to the docker container running the `bundle update` command. These are required to support dual booting apps like ones that use [bootboot](https://github.com/Shopify/bootboot).

### Changes

- add `env` property to pass environment variables to the docker container running `bundle update`
- add `gemfile-lock-files` property to list the lock files that are checked for changes
- minor doc tweak