### PR TITLE
Annotate multiple gemfile lock files

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,23 @@ builds](https://hub.docker.com/_/ruby/) at Docker Hub or build your own.
 
 Default: `ruby:slim`
 
+### `gemfile-lock-files` (optional)
+
+The Gemfile lock files to check for changes post `bundle update` or to annotate.
+
+Default: `Gemfile.lock`
+
+```yml
+steps:
+  - name: ":bundler: Update"
+    plugins:
+      - envato/bundle-update#v0.9.1:
+          update: true
+          gemfile-lock-files:
+            - Gemfile.lock
+            - Gemfile_next.lock
+```
+
 ### `env` (optional, update only)
 
 The environment variables that get passed to the docker container.
@@ -281,12 +298,6 @@ steps:
 ```
 
 Note how the values in the list can either be just a key (so the value is sourced from the environment) or a KEY=VALUE pair.
-
-### `gemfile-lock-files` (optional, update only)
-
-The Gemfile lock files to check for changes post `bundle update`.
-
-Default: `Gemfile.lock`
 
 ### `post-bundle-update` (optional, update only)
 

--- a/commands/annotate.sh
+++ b/commands/annotate.sh
@@ -21,4 +21,14 @@ args=(
   "--workdir" "/annotate"
   "--env" "GITHUB_TOKEN"
 )
-docker run "${args[@]}" "${image}" /unwrappr/annotate.sh "${repository}" "${pull_request}"
+
+# check the list of Gemfiles to annotate, these are newline delimited
+gemfile_lock_files=()
+while IFS=$'\n' read -r gemfile_lock_file ; do
+  [[ -n "${gemfile_lock_file:-}" ]] && gemfile_lock_files+=("--lock-file" "${gemfile_lock_file}")
+done <<< "$(printf '%s\n' "$(plugin_read_list GEMFILE_LOCK_FILES)")"
+
+docker run "${args[@]}" "${image}" /unwrappr/annotate.sh \
+  "${repository}" \
+  "${pull_request}" \
+  "${gemfile_lock_files[@]-}"

--- a/tests/annotate.bats
+++ b/tests/annotate.bats
@@ -84,3 +84,23 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
   unstub git
 }
+
+@test "Supports the gemfile-lock-files option" {
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_ANNOTATE=true
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_REPOSITORY=envato/ruby-service
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_PULL_REQUEST=42
+  export BUILDKITE_PLUGIN_BUNDLE_UPDATE_GEMFILE_LOCK_FILES=Gemfile_v2.lock
+
+  stub docker \
+    "pull ruby : echo pulled image" \
+    "run --interactive --tty --rm --volume /plugin/hooks/../unwrappr:/unwrappr --workdir /annotate --env GITHUB_TOKEN ruby /unwrappr/annotate.sh envato/ruby-service 42 --lock-file Gemfile_v2.lock : echo pull request annotated"
+  stub git 'remote get-url origin : echo "git@github.com:owner/project"'
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled image"
+  assert_output --partial "pull request annotated"
+  unstub docker
+  unstub git
+}

--- a/unwrappr/annotate.sh
+++ b/unwrappr/annotate.sh
@@ -11,6 +11,17 @@ bundle install --jobs="$(nproc)"
 echo "+++ :github: Annotating Github pull request"
 repository=$1
 pull_request=$2
+gemfile_lock_files=("${@:3}")
+
+if [[ ${#gemfile_lock_files[@]} -eq 0 ]]; then
+  gemfile_lock_files+=("--lock-file" "Gemfile.lock")
+fi
+
 echo "Annotating https://github.com/${repository}/pull/${pull_request}"
+echo "Files: " "${gemfile_lock_files[@]}"
 echo
-bundle exec unwrappr annotate-pull-request --repo "${repository}" --pr "${pull_request}"
+
+bundle exec unwrappr annotate-pull-request \
+  --repo "${repository}" \
+  --pr "${pull_request}" \
+  "${gemfile_lock_files[@]}"


### PR DESCRIPTION
In https://github.com/envato/bundle-update-buildkite-plugin/pull/14, support for multiple gemfile lock files was added when `bundle update`ing. Annotating those lock files wasn't supported.

This PR adds support for annotating multiple gem file lock files.

### Considerations

- This PR relies on `v0.6.0` of unwrappr being released, which adds support for annotating multiple gem file lock files. See [PR](https://github.com/envato/unwrappr/pull/86).